### PR TITLE
[fix] increase `restarts` correctly

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -324,7 +324,7 @@ Monitor.prototype.__defineGetter__('data', function () {
 // Restarts the target script associated with this instance.
 //
 Monitor.prototype.restart = function () {
-  this.times = 0;
+  this.times = this.times || 0;
   this.forceRestart = true;
 
   return !this.running


### PR DESCRIPTION
BUG: The `restarts` always be 0 or 1 no matter how many times the script be restarted.