### PR TITLE
Forcing sigkill for force terminate

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -369,7 +369,7 @@ Monitor.prototype.kill = function (forceStop) {
       //
       if (this.killTTL) {
         timer = setTimeout(function () {
-          common.kill(self.child.pid, self.killTree, self.killSignal || 'SIGKILL');
+          common.kill(self.child.pid, self.killTree, 'SIGKILL');
         }, this.killTTL);
 
         child.once('exit', function () {


### PR DESCRIPTION
The current implementation uses the same option.killSignal for soft stop as well as hard stop/kill. Quick fix for making SIGKILL happen for a child after killTTL is reached. 

Let me know your thoughts.

Best,
Michael