### PR TITLE
Switch to Chokidar.

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -9,7 +9,7 @@
 var fs = require('fs'),
     path = require('path'),
     minimatch = require('minimatch'),
-    watch = require('watch');
+    chokidar = require('chokidar');
 
 exports.name = 'watch';
 
@@ -62,20 +62,17 @@ exports.attach = function () {
     Array.prototype.push.apply(monitor.watchIgnorePatterns, data.split('\n').filter(Boolean));
   });
 
-  watch.watchTree(this.watchDirectory, function (f, curr, prev) {
-    if (!(curr === null && prev === null && typeof f === 'object')) {
-      //
-      // `curr` == null && `prev` == null && typeof f == "object" when watch
-      // finishes walking the tree to add listeners. We don't need to know
-      // about it, so we simply ignore it (anything different means that
-      // some file changed/was removed/created - that's what we want to know).
-      //
-      if (watchFilter.call(monitor, f)) {
-        monitor.emit('watch:restart', { file: f, stat: curr });
-        monitor.restart();
-      } else {
-        monitor.emit('watch:ignore', { file: f });
-      }
+  var opts = {
+    ignoreInitial: true,
+    ignored: function(fileName) {
+      return !watchFilter.call(monitor, fileName);
     }
-  });
+  };
+  // Or, ignore: function(fileName) { return !watchFilter(fileName) }
+  chokidar
+    .watch(this.watchDirectory, opts)
+    .on('all', function(f, stat) {
+      monitor.emit('watch:restart', { file: f, stat: stat });
+      monitor.restart();
+    })
 };

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "dependencies": {
     "broadway": "~0.3.6",
+    "chokidar": "^1.0.1",
     "minimatch": "~2.0.0",
     "ps-tree": "0.0.x",
-    "watch": "~0.13.0",
     "utile": "~0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey there.

This commits switches `watch` to a better file watcher, chokidar.

To summarize: chokidar is *very* stable, and is much faster on OSX, with less CPU usage because of `fsevents`.

Chokidar has been downloaded over 1.2M times last month and is used by very popular projects.