### PR TITLE
Allow passing '.' for watch directory. Fix file/stat references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can also use forever from inside your own node.js code.
   var child = new (forever.Monitor)('your-filename.js', {
     max: 3,
     silent: true,
-    args: []
+    args: ['--color']
   });
 
   child.on('exit', function () {
@@ -66,9 +66,9 @@ There are several options that you should be aware of when using forever. Most o
     // Options for restarting on watched files.
     //
     'watch': true,               // Value indicating if we should watch files.
-    'watchIgnoreDotFiles': null, // Whether to ignore file starting with a '.'
+    'watchIgnoreDotFiles': true, // Whether to ignore file starting with a '.'
     'watchIgnorePatterns': null, // Ignore patterns to use when watching files.
-    'watchDirectory': null,      // Top-level directory to watch from.
+    'watchDirectory': '.',       // Top-level directory to watch from.
 
     //
     // All or nothing options passed along to `child_process.spawn`.

--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -21,11 +21,12 @@ exports.name = 'watch';
 //
 function watchFilter(fileName) {
   var relFileName = path.relative(this.watchDirectory, fileName),
+      baseFileName = path.basename(fileName),
       length = this.watchIgnorePatterns.length,
       testName,
       i;
 
-  if (this.watchIgnoreDotFiles && path.basename(fileName)[0] === '.') {
+  if (this.watchIgnoreDotFiles && baseFileName[0] === '.' && baseFileName !== '.') {
     return false;
   }
 
@@ -72,8 +73,8 @@ exports.attach = function () {
   // Or, ignore: function(fileName) { return !watchFilter(fileName) }
   chokidar
     .watch(this.watchDirectory, opts)
-    .on('all', function(f, stat) {
-      monitor.emit('watch:restart', { file: f, stat: stat });
+    .on('all', function(event, path) {
+      monitor.emit('watch:restart', { file: path, stat: event });
       monitor.restart();
     });
 };


### PR DESCRIPTION
If you pass `'.'` as the `watchDirectory`, `chokidar` will ignore all files if you've set `watchIgnoreDotFiles` to true (which is the default).  See [here](https://github.com/paulmillr/chokidar/issues/335) for more details.  This fixes that issue.  Also, the `watch:restart` event had the file/stat variables mixed up.