### PR TITLE
Errors When Using Command Option Not Reflected to Caller

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -184,10 +184,9 @@ Monitor.prototype.start = function (restart) {
   // Re-emit messages from the child process
   this.child.on('message', onMessage);
 
-  child.on('exit', function (code, signal) {
+  function handleExit () {
     var spinning = Date.now() - self.ctime < self.minUptime;
     child.removeListener('message', onMessage);
-    self.emit('exit:code', code, signal);
 
     function letChildDie() {
       self.running = false;
@@ -214,6 +213,18 @@ Monitor.prototype.start = function (restart) {
     else {
       restartChild();
     }
+  }
+
+  child.on('exit', function (code, signal) {
+    self.emit('exit:code', code, signal);
+
+    handleExit();
+  });
+
+  child.on('error', function (err) {
+    self.emit('error', err);
+
+    handleExit();
   });
 
   return this;

--- a/test/monitor/simple-test.js
+++ b/test/monitor/simple-test.js
@@ -120,5 +120,35 @@ vows.describe('forever-monitor/monitor/simple').addBatch({
         assert.equal('' + buf, 'sample-script.js');
       }
     }
+  },
+  "attempting to start a command via npm that doesn't exist": {
+    topic: function () {
+      var child = fmonitor.start('npm start', {
+        max: 1,
+        silent: true,
+        sourceDir: '/tmp',
+        cwd: '/tmp'
+      });
+      child.on('error', this.callback.bind({}, null));
+    },
+    "should throw an error about the invalid file": function (err) {
+      assert.isNotNull(err);
+      assert.isTrue(err.message.indexOf('does not exist') !== -1);
+    }
+  },
+  "attempting to start a command that doesn't exist": {
+    topic: function () {
+      var child = fmonitor.start('surely_doesnot_exist_abcdef123', {
+        max: 1,
+        silent: true,
+        sourceDir: '/tmp',
+        cwd: '/tmp'
+      });
+      child.on('error', this.callback.bind({}, null));
+    },
+    "should throw an error about the invalid file": function (err) {
+      assert.isNotNull(err);
+      assert.isTrue(err.message.indexOf('does not exist') !== -1);
+    }
   }
 }).export(module);

--- a/test/monitor/simple-test.js
+++ b/test/monitor/simple-test.js
@@ -121,34 +121,20 @@ vows.describe('forever-monitor/monitor/simple').addBatch({
       }
     }
   },
-  "attempting to start a command via npm that doesn't exist": {
+"attempting to start a command where the path and file do not exist": {
     topic: function () {
-      var child = fmonitor.start('npm start', {
+      var child = fmonitor.start('', {
         max: 1,
         silent: true,
-        sourceDir: '/tmp',
-        cwd: '/tmp'
+        sourceDir: '/blah/not/here',
+        cwd: '/blah/not/here',
+        command: 'npm start'
       });
       child.on('error', this.callback.bind({}, null));
     },
     "should throw an error about the invalid file": function (err) {
       assert.isNotNull(err);
-      assert.isTrue(err.message.indexOf('does not exist') !== -1);
-    }
-  },
-  "attempting to start a command that doesn't exist": {
-    topic: function () {
-      var child = fmonitor.start('surely_doesnot_exist_abcdef123', {
-        max: 1,
-        silent: true,
-        sourceDir: '/tmp',
-        cwd: '/tmp'
-      });
-      child.on('error', this.callback.bind({}, null));
-    },
-    "should throw an error about the invalid file": function (err) {
-      assert.isNotNull(err);
-      assert.isTrue(err.message.indexOf('does not exist') !== -1);
+      assert.isTrue(err.message.indexOf('ENOENT') !== -1);
     }
   }
 }).export(module);


### PR DESCRIPTION
When using the "command" option to run scripts like npm that fail, the error does not get propagated back to the calling process. This fix catches those errors and re-emits them.

Errors from test case on current code:
♢ forever-monitor/monitor/simple 
(node) util.print is deprecated. Use console.log instead.
✗ Errored » callback not fired 
      in attempting to start a command where the path and file do not exist 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor an instance of Monitor with valid options 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor running error-on-timer sample three times 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor running error-on-timer sample once 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor non-node usage with a perl one-liner 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor passing node flags through command 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor attempting to start a script that doesn't exist 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js
✗ Errored » callback not fired 
      in When using forever-monitor attempting to start a command with node in the name 
      in forever-monitor/monitor/simple 
      in test/monitor/simple-test.js

Successful test after the fix:
 ♢ forever-monitor/monitor/simple 
  attempting to start a command where the path and file do not exist
    ✓ should throw an error about the invalid file
  When using forever-monitor an instance of Monitor with valid options
    ✓ should have correct properties set
  When using forever-monitor attempting to start a script that doesn't exist
    ✓ should throw an error about the invalid file
  When using forever-monitor non-node usage with a perl one-liner
    ✓ should get back moo
  When using forever-monitor an instance of Monitor with valid options calling the restart() method in less than minUptime
    ✓ should restart the child process
  When using forever-monitor passing node flags through command
    ✓ should get back function
  When using forever-monitor attempting to start a command with node in the name
    ✓ should run the script
  When using forever-monitor running error-on-timer sample once
    ✓ should emit 'exit' when completed
  When using forever-monitor running error-on-timer sample three times
    ✓ should emit 'exit' when completed