### PR TITLE
Add missing chokidar callback parameter

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -74,7 +74,7 @@ exports.attach = function () {
   // Or, ignore: function(fileName) { return !watchFilter(fileName) }
   chokidar
     .watch(this.watchDirectory, opts)
-    .on('all', function(f, stat) {
+    .on('all', function(event, f, stat) {
       monitor.emit('watch:restart', { file: f, stat: stat });
       monitor.restart();
     });


### PR DESCRIPTION
chokidar callbacks require three parameters, `event, file, stat`
