### PR TITLE
Add support for functions & regex in watchIgnorePatterns

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -30,7 +30,11 @@ function watchFilter(fileName) {
   }
 
   for (i = 0; i < length; i++) {
-    if (this.watchIgnorePatterns[i].length > 0) {
+    if (typeof this.watchIgnorePatterns[i] === 'function') {
+      if (this.watchIgnorePatterns[i](relFileName)) return false
+    } else if (this.watchIgnorePatterns[i] instanceof RegExp) {
+      if (this.watchIgnorePatterns[i].test(relFileName)) return false
+    } else if (this.watchIgnorePatterns[i].length > 0) {
       testName = (this.watchIgnorePatterns[i].charAt(0) !== '/') ? relFileName : fileName;
       if (minimatch(testName, this.watchIgnorePatterns[i], { matchBase: this.watchDirectory })) {
         return false;


### PR DESCRIPTION
Some things are very difficult or impossible with only glob patterns, the simplest solution is to add support for functions & regex.

For CLI support you could check for `.foreverignore`, & if it doesn't exist check for `.foreverignore.js` which should export an array of functions/regex/strings.