### PR TITLE
Update minimatch to avoid DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "broadway": "~0.3.6",
     "chokidar": "^1.0.1",
-    "minimatch": "~2.0.0",
+    "minimatch": "~3.0.2",
     "ps-tree": "0.0.x",
     "utile": "~0.2.1"
   },


### PR DESCRIPTION
Updated minimatch version to 3.0.2 to resolve regex denial of service vulnerability.

https://nodesecurity.io/advisories/118

Update from version 2 to 3 should not break anything.  The change was to remove the browser.js version of minimatch from the package, which is not used in forever-monitor:
https://github.com/isaacs/minimatch/commit/668a1f498b582d2e190a8712945356e638f21677