### PR TITLE
Regex problem on window os

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -501,6 +501,6 @@ Monitor.parseCommand = function (command, args) {
 // with spaces in Windows & Linux
 //
 var safetyChecks = {
-  windows: /(?:"(.*[^\/])"|(\w+))(?:\s(.*))?/,
+  windows: /(?:"(.*[^\/])"|(\w+.*[^\/]))(?:\s(.*))?/,
   linux:   /(.*?[^\\])(?: (.*)|$)/
 };


### PR DESCRIPTION
Regular expressions truncate characters below '.' char.
ex) "nodemon.cmd ==> nodemon"

bcz group 2 regex is only '\w+'. So I add regex for get full command.
full command need for run on window os. because of child-process use win-bash to window.

#140 @romandev